### PR TITLE
Make SSA_evolve_python a little quieter

### DIFF
--- a/chemevolve/CoreClasses.py
+++ b/chemevolve/CoreClasses.py
@@ -154,7 +154,6 @@ class CRS(object):
         Compare two CRS objects for ordered equality, i.e. the molecule lists
         and reaction lists must have the same values in the same order.
         '''
-        print("Calling CRS.__eq__")
         return self.molecule_list == other.molecule_list and \
                self.reactions == other.reactions
         

--- a/chemevolve/ReactionFunctions.py
+++ b/chemevolve/ReactionFunctions.py
@@ -140,7 +140,7 @@ def pick_xy(Ap_arr):
 			break
 	return x,y
 ####################################################
-def SSA_evolve_python(tau, tau_max, concentrations, CRS, random_seed=None, output_prefix=None, t_out=None):
+def SSA_evolve_python(tau, tau_max, concentrations, CRS, random_seed=None, output_prefix=None, t_out=None, verbose=False):
 
 	if (output_prefix != None and t_out == None):
 		raise ValueError('Output file prefix specified but no output frequency given, please provide an output time frequency')
@@ -169,7 +169,8 @@ def SSA_evolve_python(tau, tau_max, concentrations, CRS, random_seed=None, outpu
 			# Output data
 			Out.output_concentrations(concentrations, output_prefix,time = freq_counter)
 			freq_counter += t_out
-			print(tau)
+            if verbose:
+                print(tau)
 	Out.tidy_timeseries(CRS.molecule_list, output_prefix, delete_dat = True)
 
 	return concentrations

--- a/chemevolve/ReactionFunctions.py
+++ b/chemevolve/ReactionFunctions.py
@@ -140,7 +140,7 @@ def pick_xy(Ap_arr):
 			break
 	return x,y
 ####################################################
-def SSA_evolve_python(tau, tau_max, concentrations, CRS, random_seed, output_prefix= None,  t_out= None):
+def SSA_evolve_python(tau, tau_max, concentrations, CRS, random_seed=None, output_prefix=None, t_out=None):
 
 	if (output_prefix != None and t_out == None):
 		raise ValueError('Output file prefix specified but no output frequency given, please provide an output time frequency')
@@ -151,7 +151,8 @@ def SSA_evolve_python(tau, tau_max, concentrations, CRS, random_seed, output_pre
 	import sys
 	import random
 	freq_counter = 0.0
-	random.seed(random_seed)
+    if random_seed is not None:
+        random.seed(random_seed)
 	prop_arr = Propensity.calculate_propensities(CRS, concentrations)
 	while tau < tau_max:
 		# Pick location

--- a/chemevolve/ReactionFunctions.py
+++ b/chemevolve/ReactionFunctions.py
@@ -151,8 +151,8 @@ def SSA_evolve_python(tau, tau_max, concentrations, CRS, random_seed=None, outpu
 	import sys
 	import random
 	freq_counter = 0.0
-    if random_seed is not None:
-        random.seed(random_seed)
+	if random_seed is not None:
+		random.seed(random_seed)
 	prop_arr = Propensity.calculate_propensities(CRS, concentrations)
 	while tau < tau_max:
 		# Pick location
@@ -169,8 +169,8 @@ def SSA_evolve_python(tau, tau_max, concentrations, CRS, random_seed=None, outpu
 			# Output data
 			Out.output_concentrations(concentrations, output_prefix,time = freq_counter)
 			freq_counter += t_out
-            if verbose:
-                print(tau)
+			if verbose:
+				print(tau)
 	Out.tidy_timeseries(CRS.molecule_list, output_prefix, delete_dat = True)
 
 	return concentrations

--- a/test/test_lexer.py
+++ b/test/test_lexer.py
@@ -654,10 +654,11 @@ class TestLexer(unittest.TestCase):
                 self.assertEqual(expect, len(tokens))
 
         invalid = 'test/configs/lexer/invalid'
-        for filename in os.listdir(invalid):
-            with open(os.path.join(invalid, filename), 'rb') as f:
-                with self.assertRaises(LexerError):
-                    Lexer().lex(f.read())
+        if os.path.isdir(invalid):
+            for filename in os.listdir(invalid):
+                with open(os.path.join(invalid, filename), 'rb') as f:
+                    with self.assertRaises(LexerError):
+                        Lexer().lex(f.read())
 
     def test_lex_file(self):
         '''
@@ -684,11 +685,12 @@ class TestLexer(unittest.TestCase):
 
 
         invalid = 'test/configs/lexer/invalid'
-        for filename in os.listdir(invalid):
-            path = os.path.join(invalid, filename)
-            with open(path, 'rb') as f:
+        if os.path.isdir(invalid):
+            for filename in os.listdir(invalid):
+                path = os.path.join(invalid, filename)
+                with open(path, 'rb') as f:
+                    with self.assertRaises(LexerError):
+                        Lexer().lex_file(f)
                 with self.assertRaises(LexerError):
-                    Lexer().lex_file(f)
-            with self.assertRaises(LexerError):
-                Lexer().lex_file(path)
+                    Lexer().lex_file(path)
 

--- a/test/test_lexer.py
+++ b/test/test_lexer.py
@@ -647,11 +647,12 @@ class TestLexer(unittest.TestCase):
         without error while those in configs/lexer/invalid do not.
         '''
         valid = 'test/configs/lexer/valid'
-        for filename in os.listdir(valid):
-            with open(os.path.join(valid, filename), 'rb') as f:
-                expect = int(os.path.splitext(filename)[0])
-                tokens = Lexer().lex(f.read())
-                self.assertEqual(expect, len(tokens))
+        if os.path.isdir(valid):
+            for filename in os.listdir(valid):
+                with open(os.path.join(valid, filename), 'rb') as f:
+                    expect = int(os.path.splitext(filename)[0])
+                    tokens = Lexer().lex(f.read())
+                    self.assertEqual(expect, len(tokens))
 
         invalid = 'test/configs/lexer/invalid'
         if os.path.isdir(invalid):
@@ -668,21 +669,21 @@ class TestLexer(unittest.TestCase):
         configs/lexer/invalid raise errors.
         '''
         valid = 'test/configs/lexer/valid'
-        for filename in os.listdir(valid):
-            path = os.path.join(valid, filename)
-            lexer = Lexer()
-            with open(path, 'rb') as f:
-                expected = lexer.lex(f.read(), reset=True)
+        if os.path.isdir(valid):
+            for filename in os.listdir(valid):
+                path = os.path.join(valid, filename)
+                lexer = Lexer()
+                with open(path, 'rb') as f:
+                    expected = lexer.lex(f.read(), reset=True)
 
-            # Lex the file from a file handle
-            with open(path, 'rb') as f:
-                got = lexer.lex_file(f, reset=True)
-            self.assertEqual(expected, got)
+                # Lex the file from a file handle
+                with open(path, 'rb') as f:
+                    got = lexer.lex_file(f, reset=True)
+                self.assertEqual(expected, got)
 
-            # Lex the file from a filename
-            got = lexer.lex_file(path, reset=True)
-            self.assertEqual(expected, got)
-
+                # Lex the file from a filename
+                got = lexer.lex_file(path, reset=True)
+                self.assertEqual(expected, got)
 
         invalid = 'test/configs/lexer/invalid'
         if os.path.isdir(invalid):

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -147,10 +147,11 @@ class TestParser(unittest.TestCase):
                 self.assertTrue(crs)
 
         invalid = 'test/configs/parser/invalid'
-        for filename in os.listdir(invalid):
-            with open(os.path.join(invalid, filename), 'rb') as f:
-                with self.assertRaises(Exception):
-                    Parser().parse(f.read())
+        if os.path.isdir(invalid):
+            for filename in os.listdir(invalid):
+                with open(os.path.join(invalid, filename), 'rb') as f:
+                    with self.assertRaises(Exception):
+                        Parser().parse(f.read())
 
     def test_parse_file(self):
         '''
@@ -176,11 +177,12 @@ class TestParser(unittest.TestCase):
 
 
         invalid = 'test/configs/parser/invalid'
-        for filename in os.listdir(invalid):
-            path = os.path.join(invalid, filename)
-            with open(path, 'rb') as f:
+        if os.path.isdir(invalid):
+            for filename in os.listdir(invalid):
+                path = os.path.join(invalid, filename)
+                with open(path, 'rb') as f:
+                    with self.assertRaises(Exception):
+                        Parser().parse_file(f)
                 with self.assertRaises(Exception):
-                    Parser().parse_file(f)
-            with self.assertRaises(Exception):
-                Parser().parse_file(path)
+                    Parser().parse_file(path)
 

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -141,10 +141,11 @@ class TestParser(unittest.TestCase):
         without error while those in configs/parser/invalid do not.
         '''
         valid = 'test/configs/parser/valid'
-        for filename in os.listdir(valid):
-            with open(os.path.join(valid, filename), 'rb') as f:
-                crs = Parser().parse(f.read())
-                self.assertTrue(crs)
+        if os.path.isdir(valid):
+            for filename in os.listdir(valid):
+                with open(os.path.join(valid, filename), 'rb') as f:
+                    crs = Parser().parse(f.read())
+                    self.assertTrue(crs)
 
         invalid = 'test/configs/parser/invalid'
         if os.path.isdir(invalid):
@@ -160,21 +161,21 @@ class TestParser(unittest.TestCase):
         using `parse`. Ensure that files in configs/parse/invalid raise errors.
         '''
         valid = 'test/configs/parser/valid'
-        for filename in os.listdir(valid):
-            path = os.path.join(valid, filename)
-            parser = Parser()
-            with open(path, 'rb') as f:
-                expected = parser.parse(f.read())
+        if os.path.isdir(valid):
+            for filename in os.listdir(valid):
+                path = os.path.join(valid, filename)
+                parser = Parser()
+                with open(path, 'rb') as f:
+                    expected = parser.parse(f.read())
 
-            # Parse the file from a file handle
-            with open(path, 'rb') as f:
-                got = parser.parse_file(f)
-            self.assertEqual(expected, got)
+                # Parse the file from a file handle
+                with open(path, 'rb') as f:
+                    got = parser.parse_file(f)
+                self.assertEqual(expected, got)
 
-            # Parse the file from a filename
-            got = parser.parse_file(path)
-            self.assertEqual(expected, got)
-
+                # Parse the file from a filename
+                got = parser.parse_file(path)
+                self.assertEqual(expected, got)
 
         invalid = 'test/configs/parser/invalid'
         if os.path.isdir(invalid):

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -118,11 +118,12 @@ class TestParser(unittest.TestCase):
         self.assertEqual(4, len(p.reaction_list))
 
         reactions = [
-                Reaction(0, ['A'], [2], ['AA'], [1], 1.0, [], [], 'STD'),
-                Reaction(1, ['A','B'], [1,1], ['AB'], [1], 0.5, [], [], 'QED'),
-                Reaction(2, ['AA'], [1], ['A'], [2], 1.5, ['AA'], [2.3], 'STD'),
-                Reaction(3, ['AB'], [1], ['A','B'], [1,1], 0.25, ['A','B'], [1e-3,1e-2], 'STD')
+                Reaction(0, [0], [2], [1], [1], 1.0, [], [], 'STD'),
+                Reaction(1, [0,2], [1,1], [3], [1], 0.5, [], [], 'QED'),
+                Reaction(2, [1], [1], [0], [2], 1.5, [1], [2.3], 'STD'),
+                Reaction(3, [3], [1], [0,2], [1,1], 0.25, [0,2], [1e-3,1e-2], 'STD')
                 ]
+
         for expect, got in zip(reactions, p.reaction_list):
             self.assertEqual(expect.ID, got.ID)
             self.assertEqual(expect.reactants, got.reactants)


### PR DESCRIPTION
This pull request fixes a few unittesting errors, makes the `random_seed` argument to `SSA_evolve_python` optional, and adds the `verbose` keyword argument.

If `random_seed` is not `None`, then the random number generator is seeded using its value; otherwise, the default seed is used.

If `verbose` is `True`, then status messages are printed as the SSA algorithm evaluates.